### PR TITLE
Add weather dashboard with 7-day forecast and emojis

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,7 +128,12 @@ const demos = [
   },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
-  { route: '/weather-dashboard', title: 'Weather Dashboard', description: '7-day forecast powered by Open-Meteo.', category: 'Dashboards' },
+  {
+    route: '/weather-dashboard',
+    title: 'Weather Dashboard',
+    description: '7-day forecast powered by Open-Meteo.',
+    category: 'Dashboards',
+  },
 ];
 
 // Get unique categories

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,6 +128,7 @@ const demos = [
   },
   { route: '/wizard', title: 'Wizard', description: 'Multi-step wizard demo.', category: 'Forms' },
   { route: '/write-to-s3', title: 'Write to S3', description: 'Write data to Amazon S3.', category: 'Integration' },
+  { route: '/weather-dashboard', title: 'Weather Dashboard', description: '7-day forecast powered by Open-Meteo.', category: 'Dashboards' },
 ];
 
 // Get unique categories

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -13,6 +13,7 @@ import Cards from '@cloudscape-design/components/cards';
 import Link from '@cloudscape-design/components/link';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
 import Badge from '@cloudscape-design/components/badge';
+import Button from '@cloudscape-design/components/button';
 import { format } from 'date-fns';
 
 import '../../styles/base.scss';
@@ -50,6 +51,25 @@ function weatherCodeToText(code: number): string {
   if (code === 95) return 'Thunderstorm';
   if ([96, 99].includes(code)) return 'Thunderstorm with hail';
   return 'Unknown';
+}
+
+function weatherCodeToEmoji(code: number): string {
+  if (code === 0) return '☀️';
+  if ([1].includes(code)) return '🌤️';
+  if ([2].includes(code)) return '⛅';
+  if (code === 3) return '☁️';
+  if ([45, 48].includes(code)) return '🌫️';
+  if ([51, 53, 55].includes(code)) return '🌦️';
+  if ([56, 57].includes(code)) return '🥶🌦️';
+  if ([61, 63, 65].includes(code)) return '🌧️';
+  if ([66, 67].includes(code)) return '🥶🌧️';
+  if ([71, 73, 75].includes(code)) return '🌨️';
+  if (code === 77) return '❄️';
+  if ([80, 81, 82].includes(code)) return '🌦️';
+  if ([85, 86].includes(code)) return '❄️';
+  if (code === 95) return '⛈️';
+  if ([96, 99].includes(code)) return '⛈️';
+  return '🌈';
 }
 
 async function geocode(name: string): Promise<GeoResult[]> {
@@ -157,7 +177,27 @@ export function App() {
       toolsHide
       content={
         <ContentLayout
-          header={<Header variant="h1">Weather Dashboard</Header>}
+          header={
+            <Header
+              variant="h1"
+              actions={
+                <Button
+                  iconName="angle-left"
+                  onClick={() => {
+                    if (window.history.length > 1) {
+                      window.history.back();
+                    } else {
+                      window.location.href = '/';
+                    }
+                  }}
+                >
+                  Back
+                </Button>
+              }
+            >
+              Weather Dashboard
+            </Header>
+          }
         >
           <SpaceBetween size="l">
             <Container
@@ -191,6 +231,26 @@ export function App() {
               </SpaceBetween>
             </Container>
 
+            <Container header={<Header>Today's forecast</Header>}>
+              {loading && <StatusIndicator type="loading">Loading forecast</StatusIndicator>}
+              {error && <StatusIndicator type="error">{error}</StatusIndicator>}
+              {!loading && !error && forecast && forecast.length > 0 && (
+                <Box>
+                  <SpaceBetween size="s">
+                    <Box fontWeight="bold">
+                      {weatherCodeToEmoji(forecast[0].weathercode)} {format(new Date(forecast[0].date), 'EEEE, MMM d')}
+                    </Box>
+                    <Box variant="p">{weatherCodeToText(forecast[0].weathercode)}</Box>
+                    <Box variant="p">High: {Math.round(forecast[0].max)}°C</Box>
+                    <Box variant="p">Low: {Math.round(forecast[0].min)}°C</Box>
+                  </SpaceBetween>
+                </Box>
+              )}
+              {!loading && !error && (!forecast || forecast.length === 0) && (
+                <Box variant="p">No data</Box>
+              )}
+            </Container>
+
             <Container header={<Header counter={headerCounter}>7-day forecast</Header>}>
               {loading && <StatusIndicator type="loading">Loading forecast</StatusIndicator>}
               {error && <StatusIndicator type="error">{error}</StatusIndicator>}
@@ -214,7 +274,7 @@ export function App() {
                   ]}
                   items={forecast.map(d => ({
                     id: d.date,
-                    title: format(new Date(d.date), 'EEE, MMM d'),
+                    title: `${weatherCodeToEmoji(d.weathercode)} ${format(new Date(d.date), 'EEE, MMM d')}`,
                     description: (
                       <SpaceBetween size="xs">
                         <Box variant="p">{weatherCodeToText(d.weathercode)}</Box>

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -1,0 +1,246 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import AppLayout from '@cloudscape-design/components/app-layout';
+import ContentLayout from '@cloudscape-design/components/content-layout';
+import Header from '@cloudscape-design/components/header';
+import Container from '@cloudscape-design/components/container';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Box from '@cloudscape-design/components/box';
+import Autosuggest, { AutosuggestProps } from '@cloudscape-design/components/autosuggest';
+import Cards from '@cloudscape-design/components/cards';
+import Link from '@cloudscape-design/components/link';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Badge from '@cloudscape-design/components/badge';
+import { format } from 'date-fns';
+
+import '../../styles/base.scss';
+
+interface GeoResult {
+  id: number;
+  name: string;
+  latitude: number;
+  longitude: number;
+  country?: string;
+  admin1?: string;
+}
+
+interface ForecastDay {
+  date: string; // ISO date
+  min: number;
+  max: number;
+  weathercode: number;
+}
+
+function weatherCodeToText(code: number): string {
+  // Mapping from https://open-meteo.com/en/docs#api_form with consolidated groups
+  if (code === 0) return 'Clear sky';
+  if ([1, 2].includes(code)) return 'Mainly clear';
+  if (code === 3) return 'Overcast';
+  if ([45, 48].includes(code)) return 'Fog';
+  if ([51, 53, 55].includes(code)) return 'Drizzle';
+  if ([56, 57].includes(code)) return 'Freezing drizzle';
+  if ([61, 63, 65].includes(code)) return 'Rain';
+  if ([66, 67].includes(code)) return 'Freezing rain';
+  if ([71, 73, 75].includes(code)) return 'Snowfall';
+  if (code === 77) return 'Snow grains';
+  if ([80, 81, 82].includes(code)) return 'Rain showers';
+  if ([85, 86].includes(code)) return 'Snow showers';
+  if (code === 95) return 'Thunderstorm';
+  if ([96, 99].includes(code)) return 'Thunderstorm with hail';
+  return 'Unknown';
+}
+
+async function geocode(name: string): Promise<GeoResult[]> {
+  const url = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(
+    name,
+  )}&count=5&language=en&format=json`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Failed to search locations');
+  const data = await res.json();
+  const results = (data?.results || []) as any[];
+  return results.map(r => ({
+    id: r.id,
+    name: r.name,
+    latitude: r.latitude,
+    longitude: r.longitude,
+    country: r.country,
+    admin1: r.admin1,
+  }));
+}
+
+async function fetchForecast(lat: number, lon: number): Promise<ForecastDay[]> {
+  const daily = [
+    'temperature_2m_max',
+    'temperature_2m_min',
+    'weathercode',
+  ].join(',');
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&daily=${daily}&forecast_days=7&timezone=auto`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('Failed to fetch forecast');
+  const data = await res.json();
+  const days: ForecastDay[] = (data?.daily?.time || []).map((t: string, i: number) => ({
+    date: t,
+    min: Number(data.daily.temperature_2m_min?.[i] ?? 0),
+    max: Number(data.daily.temperature_2m_max?.[i] ?? 0),
+    weathercode: Number(data.daily.weathercode?.[i] ?? 0),
+  }));
+  return days;
+}
+
+export function App() {
+  const [query, setQuery] = useState('San Francisco');
+  const [suggestions, setSuggestions] = useState<AutosuggestProps.Option[]>([]);
+  const [selected, setSelected] = useState<GeoResult | null>(null);
+  const [forecast, setForecast] = useState<ForecastDay[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const suggestionLoad = useCallback(async (value: string) => {
+    if (!value || value.length < 2) {
+      setSuggestions([]);
+      return;
+    }
+    try {
+      const results = await geocode(value);
+      setSuggestions(
+        results.map(r => ({
+          value: `${r.name}${r.admin1 ? ', ' + r.admin1 : ''}${r.country ? ', ' + r.country : ''}`,
+          label: `${r.name}${r.admin1 ? ', ' + r.admin1 : ''}${r.country ? ', ' + r.country : ''}`,
+          description: `Lat ${r.latitude.toFixed(2)}, Lon ${r.longitude.toFixed(2)}`,
+          tags: [r.latitude.toFixed(2), r.longitude.toFixed(2)],
+          r,
+        })) as AutosuggestProps.Option[],
+      );
+    } catch (e: any) {
+      // Silent fail on suggestions
+      setSuggestions([]);
+    }
+  }, []);
+
+  const loadForecast = useCallback(async (loc: GeoResult) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchForecast(loc.latitude, loc.longitude);
+      setForecast(data);
+    } catch (e: any) {
+      setError('Unable to load weather data');
+      setForecast(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Initial load with default location
+  useEffect(() => {
+    (async () => {
+      try {
+        const results = await geocode(query);
+        const first = results[0];
+        if (first) {
+          setSelected(first);
+          await loadForecast(first);
+        }
+      } catch {
+        // ignore
+      }
+    })();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const headerCounter = useMemo(() => (forecast ? `(${forecast.length})` : undefined), [forecast]);
+
+  return (
+    <AppLayout
+      navigationHide
+      toolsHide
+      content={
+        <ContentLayout
+          header={<Header variant="h1">Weather Dashboard</Header>}
+        >
+          <SpaceBetween size="l">
+            <Container
+              header={<Header description="Search for a city to view the 7-day forecast">Location</Header>}
+            >
+              <SpaceBetween size="s">
+                <Autosuggest
+                  onChange={({ detail }) => setQuery(detail.value)}
+                  value={query}
+                  onLoadItems={({ detail }) => suggestionLoad(detail.filteringText)}
+                  onSelect={({ detail }) => {
+                    const option = detail.option as any;
+                    if (option?.r) {
+                      setSelected(option.r as GeoResult);
+                      loadForecast(option.r as GeoResult);
+                    }
+                  }}
+                  options={suggestions}
+                  placeholder="Search city (e.g., London)"
+                  statusType="finished"
+                  ariaLabel="City search"
+                  filteringType="manual"
+                />
+                {selected ? (
+                  <Box variant="p">
+                    Selected: <Badge color="blue">{selected.name}{selected.admin1 ? `, ${selected.admin1}` : ''}{selected.country ? `, ${selected.country}` : ''}</Badge>
+                  </Box>
+                ) : (
+                  <StatusIndicator type="pending">Choose a location</StatusIndicator>
+                )}
+              </SpaceBetween>
+            </Container>
+
+            <Container header={<Header counter={headerCounter}>7-day forecast</Header>}>
+              {loading && <StatusIndicator type="loading">Loading forecast</StatusIndicator>}
+              {error && <StatusIndicator type="error">{error}</StatusIndicator>}
+              {!loading && !error && forecast && (
+                <Cards
+                  ariaLabels={{
+                    itemSelectionLabel: (e, n) => `select ${n.title}`,
+                    selectionGroupLabel: 'Forecast selection',
+                  }}
+                  cardDefinition={{
+                    header: item => <Box fontWeight="bold">{item.title}</Box>,
+                    sections: [
+                      { id: 'desc', content: item => item.description },
+                    ],
+                  }}
+                  cardsPerRow={[
+                    { cards: 1, minWidth: 0 },
+                    { cards: 2, minWidth: 500 },
+                    { cards: 3, minWidth: 800 },
+                    { cards: 4, minWidth: 1100 },
+                  ]}
+                  items={forecast.map(d => ({
+                    id: d.date,
+                    title: format(new Date(d.date), 'EEE, MMM d'),
+                    description: (
+                      <SpaceBetween size="xs">
+                        <Box variant="p">{weatherCodeToText(d.weathercode)}</Box>
+                        <Box variant="p">High: {Math.round(d.max)}°C</Box>
+                        <Box variant="p">Low: {Math.round(d.min)}°C</Box>
+                        {selected && (
+                          <Link external href={`https://open-meteo.com/en/docs#api_form`}>
+                            API details
+                          </Link>
+                        )}
+                      </SpaceBetween>
+                    ),
+                  }))}
+                  loadingText="Loading forecast"
+                  trackBy="id"
+                  visibleSections={['desc']}
+                  header={<Header variant="h2">Daily outlook</Header>}
+                />
+              )}
+              {!loading && !error && !forecast && (
+                <Box variant="p">No data</Box>
+              )}
+            </Container>
+          </SpaceBetween>
+        </ContentLayout>
+      }
+    />
+  );
+}

--- a/src/pages/weather-dashboard/app.tsx
+++ b/src/pages/weather-dashboard/app.tsx
@@ -91,11 +91,7 @@ async function geocode(name: string): Promise<GeoResult[]> {
 }
 
 async function fetchForecast(lat: number, lon: number): Promise<ForecastDay[]> {
-  const daily = [
-    'temperature_2m_max',
-    'temperature_2m_min',
-    'weathercode',
-  ].join(',');
+  const daily = ['temperature_2m_max', 'temperature_2m_min', 'weathercode'].join(',');
   const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&daily=${daily}&forecast_days=7&timezone=auto`;
   const res = await fetch(url);
   if (!res.ok) throw new Error('Failed to fetch forecast');
@@ -200,9 +196,7 @@ export function App() {
           }
         >
           <SpaceBetween size="l">
-            <Container
-              header={<Header description="Search for a city to view the 7-day forecast">Location</Header>}
-            >
+            <Container header={<Header description="Search for a city to view the 7-day forecast">Location</Header>}>
               <SpaceBetween size="s">
                 <Autosuggest
                   onChange={({ detail }) => setQuery(detail.value)}
@@ -223,7 +217,12 @@ export function App() {
                 />
                 {selected ? (
                   <Box variant="p">
-                    Selected: <Badge color="blue">{selected.name}{selected.admin1 ? `, ${selected.admin1}` : ''}{selected.country ? `, ${selected.country}` : ''}</Badge>
+                    Selected:{' '}
+                    <Badge color="blue">
+                      {selected.name}
+                      {selected.admin1 ? `, ${selected.admin1}` : ''}
+                      {selected.country ? `, ${selected.country}` : ''}
+                    </Badge>
                   </Box>
                 ) : (
                   <StatusIndicator type="pending">Choose a location</StatusIndicator>
@@ -246,9 +245,7 @@ export function App() {
                   </SpaceBetween>
                 </Box>
               )}
-              {!loading && !error && (!forecast || forecast.length === 0) && (
-                <Box variant="p">No data</Box>
-              )}
+              {!loading && !error && (!forecast || forecast.length === 0) && <Box variant="p">No data</Box>}
             </Container>
 
             <Container header={<Header counter={headerCounter}>7-day forecast</Header>}>
@@ -262,9 +259,7 @@ export function App() {
                   }}
                   cardDefinition={{
                     header: item => <Box fontWeight="bold">{item.title}</Box>,
-                    sections: [
-                      { id: 'desc', content: item => item.description },
-                    ],
+                    sections: [{ id: 'desc', content: item => item.description }],
                   }}
                   cardsPerRow={[
                     { cards: 1, minWidth: 0 },
@@ -294,9 +289,7 @@ export function App() {
                   header={<Header variant="h2">Daily outlook</Header>}
                 />
               )}
-              {!loading && !error && !forecast && (
-                <Box variant="p">No data</Box>
-              )}
+              {!loading && !error && !forecast && <Box variant="p">No data</Box>}
             </Container>
           </SpaceBetween>
         </ContentLayout>

--- a/src/pages/weather-dashboard/index.tsx
+++ b/src/pages/weather-dashboard/index.tsx
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function WeatherDashboardDemo() {
+  return <App />;
+}


### PR DESCRIPTION
## Purpose

The user requested a new weather dashboard feature that displays weather forecasts using the Open-Meteo API. They wanted a 7-day forecast with visual enhancements including weather emojis for each forecast day, navigation back to previous pages, and a dedicated daily forecast section for today's weather.

## Code changes

- **Added weather dashboard route** to main index page with "Dashboards" category
- **Created new weather dashboard component** (`/weather-dashboard/`) with:
  - City search using Open-Meteo geocoding API
  - 7-day weather forecast display using Open-Meteo weather API
  - Weather condition emojis for visual representation
  - Today's detailed forecast section
  - Back navigation button to return to previous pages
  - Responsive card layout for forecast display
  - Error handling and loading states
- **Integrated weather code mapping** for converting API codes to readable text and emojis
- **Added temperature display** in Celsius with high/low values for each dayTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/604730003d334a879c3dec2640e01fc0/quantum-sanctuary)

👀 [Preview Link](https://604730003d334a879c3dec2640e01fc0-quantum-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>604730003d334a879c3dec2640e01fc0</projectId>-->
<!--<branchName>quantum-sanctuary</branchName>-->