### PR TITLE
feat: Add Network Administration Dashboard page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,6 +31,12 @@ const demos = [
   },
   { route: '/dashboard', title: 'Service Dashboard', description: 'Dashboard layout demo.', category: 'Dashboards' },
   {
+    route: '/network-dashboard',
+    title: 'Network Administration Dashboard',
+    description: 'Interactive network monitoring dashboard with traffic charts and device management.',
+    category: 'Dashboards',
+  },
+  {
     route: '/delete-one-click',
     title: 'One-click Delete',
     description: 'Delete with a single click.',

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -39,7 +39,7 @@ export function App() {
   // Generate dynamic data for Credit Usage chart
   const generateCreditData = () => {
     const days = ['x1', 'x2', 'x3', 'x4', 'x5'];
-    return days.map((day) => ({
+    return days.map(day => ({
       x: day,
       y: Math.floor(Math.random() * 200) + 100,
     }));
@@ -71,8 +71,8 @@ export function App() {
     setRefreshKey(refreshKey + 1);
   };
 
-  const filteredDevices = devices.filter((device) =>
-    Object.values(device).some((value) => value.toLowerCase().includes(filteringText.toLowerCase()))
+  const filteredDevices = devices.filter(device =>
+    Object.values(device).some(value => value.toLowerCase().includes(filteringText.toLowerCase())),
   );
 
   const paginatedDevices = filteredDevices.slice((currentPageIndex - 1) * 5, currentPageIndex * 5);
@@ -165,15 +165,15 @@ export function App() {
                     {
                       title: 'Site 1',
                       type: 'area',
-                      data: networkData.map((d) => ({ x: d.x, y: d.y1 })),
+                      data: networkData.map(d => ({ x: d.x, y: d.y1 })),
                     },
                     {
                       title: 'Site 2',
                       type: 'area',
-                      data: networkData.map((d) => ({ x: d.x, y: d.y2 })),
+                      data: networkData.map(d => ({ x: d.x, y: d.y2 })),
                     },
                   ]}
-                  xDomain={networkData.map((d) => d.x)}
+                  xDomain={networkData.map(d => d.x)}
                   yDomain={[0, 100]}
                   i18nStrings={{
                     filterLabel: 'Filter displayed data',
@@ -181,8 +181,8 @@ export function App() {
                     filterSelectedAriaLabel: 'selected',
                     legendAriaLabel: 'Legend',
                     chartAriaRoleDescription: 'area chart',
-                    xTickFormatter: (value) => value,
-                    yTickFormatter: (value) => `${value}`,
+                    xTickFormatter: value => value,
+                    yTickFormatter: value => `${value}`,
                   }}
                   ariaLabel="Network traffic area chart"
                   height={300}
@@ -224,7 +224,7 @@ export function App() {
                       data: creditData,
                     },
                   ]}
-                  xDomain={creditData.map((d) => d.x)}
+                  xDomain={creditData.map(d => d.x)}
                   yDomain={[0, 300]}
                   i18nStrings={{
                     filterLabel: 'Filter displayed data',
@@ -232,8 +232,8 @@ export function App() {
                     filterSelectedAriaLabel: 'selected',
                     legendAriaLabel: 'Legend',
                     chartAriaRoleDescription: 'bar chart',
-                    xTickFormatter: (value) => value,
-                    yTickFormatter: (value) => `${value}`,
+                    xTickFormatter: value => value,
+                    yTickFormatter: value => `${value}`,
                   }}
                   ariaLabel="Credit usage bar chart"
                   height={300}
@@ -278,37 +278,37 @@ export function App() {
                 {
                   id: 'name',
                   header: 'Device Name',
-                  cell: (item) => item.name,
+                  cell: item => item.name,
                   sortingField: 'name',
                 },
                 {
                   id: 'type',
                   header: 'Type',
-                  cell: (item) => item.type,
+                  cell: item => item.type,
                   sortingField: 'type',
                 },
                 {
                   id: 'ipAddress',
                   header: 'IP Address',
-                  cell: (item) => item.ipAddress,
+                  cell: item => item.ipAddress,
                   sortingField: 'ipAddress',
                 },
                 {
                   id: 'status',
                   header: 'Status',
-                  cell: (item) => item.status,
+                  cell: item => item.status,
                   sortingField: 'status',
                 },
                 {
                   id: 'location',
                   header: 'Location',
-                  cell: (item) => item.location,
+                  cell: item => item.location,
                   sortingField: 'location',
                 },
                 {
                   id: 'lastSeen',
                   header: 'Last Seen',
-                  cell: (item) => item.lastSeen,
+                  cell: item => item.lastSeen,
                 },
               ]}
               items={paginatedDevices}

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT-0
 import React, { useState } from 'react';
 
-import AppLayout from '@cloudscape-design/components/app-layout';
 import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
 import Button from '@cloudscape-design/components/button';
 import Flashbar from '@cloudscape-design/components/flashbar';
@@ -18,7 +17,6 @@ import TextFilter from '@cloudscape-design/components/text-filter';
 import Pagination from '@cloudscape-design/components/pagination';
 import CollectionPreferences from '@cloudscape-design/components/collection-preferences';
 import TopNavigation from '@cloudscape-design/components/top-navigation';
-import Icon from '@cloudscape-design/components/icon';
 
 import { CustomAppLayout } from '../commons/common-components';
 
@@ -85,33 +83,16 @@ export function App() {
         identity={{
           href: '#',
           title: 'Service name',
-          logo: {
-            src: '',
-            alt: 'Logo',
-          },
         }}
         utilities={[
           {
             type: 'button',
-            text: 'Link',
-            href: '#',
-            external: true,
-            externalIconAriaLabel: ' (opens in a new tab)',
-          },
-          {
-            type: 'button',
             iconName: 'notification',
-            title: 'Notifications',
-            ariaLabel: 'Notifications (unread)',
+            ariaLabel: 'Notifications',
             badge: true,
-            disableUtilityCollapse: false,
+            disableUtilityCollapse: true,
           },
-          {
-            type: 'button',
-            iconName: 'settings',
-            title: 'Settings',
-            ariaLabel: 'Settings',
-          },
+          { type: 'button', iconName: 'settings', title: 'Settings', ariaLabel: 'Settings' },
           {
             type: 'menu-dropdown',
             text: 'Customer name',
@@ -121,21 +102,6 @@ export function App() {
               { id: 'profile', text: 'Profile' },
               { id: 'preferences', text: 'Preferences' },
               { id: 'security', text: 'Security' },
-              {
-                id: 'support-group',
-                text: 'Support',
-                items: [
-                  {
-                    id: 'documentation',
-                    text: 'Documentation',
-                    href: '#',
-                    external: true,
-                    externalIconAriaLabel: ' (opens in new tab)',
-                  },
-                  { id: 'support', text: 'Support' },
-                  { id: 'feedback', text: 'Feedback' },
-                ],
-              },
               { id: 'signout', text: 'Sign out' },
             ],
           },

--- a/src/pages/network-dashboard/app.tsx
+++ b/src/pages/network-dashboard/app.tsx
@@ -1,0 +1,398 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+
+import AppLayout from '@cloudscape-design/components/app-layout';
+import BreadcrumbGroup from '@cloudscape-design/components/breadcrumb-group';
+import Button from '@cloudscape-design/components/button';
+import Flashbar from '@cloudscape-design/components/flashbar';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Grid from '@cloudscape-design/components/grid';
+import Container from '@cloudscape-design/components/container';
+import AreaChart from '@cloudscape-design/components/area-chart';
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Table from '@cloudscape-design/components/table';
+import Box from '@cloudscape-design/components/box';
+import TextFilter from '@cloudscape-design/components/text-filter';
+import Pagination from '@cloudscape-design/components/pagination';
+import CollectionPreferences from '@cloudscape-design/components/collection-preferences';
+import TopNavigation from '@cloudscape-design/components/top-navigation';
+import Icon from '@cloudscape-design/components/icon';
+
+import { CustomAppLayout } from '../commons/common-components';
+
+export function App() {
+  const [filteringText, setFilteringText] = useState('');
+  const [currentPageIndex, setCurrentPageIndex] = useState(1);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [selectedItems, setSelectedItems] = useState([]);
+
+  // Generate dynamic data for Network Traffic chart
+  const generateNetworkData = () => {
+    const days = ['x1', 'x2', 'x3', 'x4', 'x5', 'x6', 'x7', 'x8', 'x9', 'x10', 'x11', 'x12'];
+    return days.map((day, index) => ({
+      x: day,
+      y1: Math.floor(Math.random() * 50) + 30,
+      y2: Math.floor(Math.random() * 40) + 40,
+    }));
+  };
+
+  // Generate dynamic data for Credit Usage chart
+  const generateCreditData = () => {
+    const days = ['x1', 'x2', 'x3', 'x4', 'x5'];
+    return days.map((day) => ({
+      x: day,
+      y: Math.floor(Math.random() * 200) + 100,
+    }));
+  };
+
+  const [networkData, setNetworkData] = useState(generateNetworkData());
+  const [creditData, setCreditData] = useState(generateCreditData());
+
+  // Sample device data
+  const generateDeviceData = () => {
+    const deviceTypes = ['Router', 'Switch', 'Access Point', 'Firewall', 'Server'];
+    const statuses = ['Active', 'Inactive', 'Warning'];
+    return Array.from({ length: 12 }, (_, i) => ({
+      id: `device-${i + 1}`,
+      name: `Device ${i + 1}`,
+      type: deviceTypes[Math.floor(Math.random() * deviceTypes.length)],
+      ipAddress: `192.168.1.${10 + i}`,
+      status: statuses[Math.floor(Math.random() * statuses.length)],
+      location: `Floor ${Math.floor(i / 4) + 1}`,
+      lastSeen: `${Math.floor(Math.random() * 60)} min ago`,
+    }));
+  };
+
+  const [devices] = useState(generateDeviceData());
+
+  const handleRefreshData = () => {
+    setNetworkData(generateNetworkData());
+    setCreditData(generateCreditData());
+    setRefreshKey(refreshKey + 1);
+  };
+
+  const filteredDevices = devices.filter((device) =>
+    Object.values(device).some((value) => value.toLowerCase().includes(filteringText.toLowerCase()))
+  );
+
+  const paginatedDevices = filteredDevices.slice((currentPageIndex - 1) * 5, currentPageIndex * 5);
+
+  return (
+    <>
+      <TopNavigation
+        identity={{
+          href: '#',
+          title: 'Service name',
+          logo: {
+            src: '',
+            alt: 'Logo',
+          },
+        }}
+        utilities={[
+          {
+            type: 'button',
+            text: 'Link',
+            href: '#',
+            external: true,
+            externalIconAriaLabel: ' (opens in a new tab)',
+          },
+          {
+            type: 'button',
+            iconName: 'notification',
+            title: 'Notifications',
+            ariaLabel: 'Notifications (unread)',
+            badge: true,
+            disableUtilityCollapse: false,
+          },
+          {
+            type: 'button',
+            iconName: 'settings',
+            title: 'Settings',
+            ariaLabel: 'Settings',
+          },
+          {
+            type: 'menu-dropdown',
+            text: 'Customer name',
+            description: 'customer@example.com',
+            iconName: 'user-profile',
+            items: [
+              { id: 'profile', text: 'Profile' },
+              { id: 'preferences', text: 'Preferences' },
+              { id: 'security', text: 'Security' },
+              {
+                id: 'support-group',
+                text: 'Support',
+                items: [
+                  {
+                    id: 'documentation',
+                    text: 'Documentation',
+                    href: '#',
+                    external: true,
+                    externalIconAriaLabel: ' (opens in new tab)',
+                  },
+                  { id: 'support', text: 'Support' },
+                  { id: 'feedback', text: 'Feedback' },
+                ],
+              },
+              { id: 'signout', text: 'Sign out' },
+            ],
+          },
+        ]}
+        i18nStrings={{
+          searchIconAriaLabel: 'Search',
+          searchDismissIconAriaLabel: 'Close search',
+          overflowMenuTriggerText: 'More',
+          overflowMenuTitleText: 'All',
+          overflowMenuBackIconAriaLabel: 'Back',
+          overflowMenuDismissIconAriaLabel: 'Close menu',
+        }}
+      />
+      <CustomAppLayout
+        contentType="table"
+        breadcrumbs={
+          <BreadcrumbGroup
+            items={[
+              { text: 'Service', href: '#' },
+              { text: 'Administrative Dashboard', href: '#' },
+            ]}
+            ariaLabel="Breadcrumbs"
+          />
+        }
+        content={
+          <SpaceBetween size="l">
+            <Header
+              variant="h1"
+              actions={
+                <Button variant="primary" iconName="external" onClick={handleRefreshData}>
+                  Refresh Data
+                </Button>
+              }
+              description="Network Traffic, Credit Usage, and Your Devices"
+            >
+              Network Administration Dashboard
+            </Header>
+
+            <Flashbar
+              items={[
+                {
+                  type: 'warning',
+                  dismissible: true,
+                  content: 'This is a warning message',
+                  id: 'warning-message',
+                },
+              ]}
+            />
+
+            <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+              <Container
+                header={
+                  <Header variant="h2" description="">
+                    Network traffic
+                  </Header>
+                }
+              >
+                <AreaChart
+                  key={`network-${refreshKey}`}
+                  series={[
+                    {
+                      title: 'Site 1',
+                      type: 'area',
+                      data: networkData.map((d) => ({ x: d.x, y: d.y1 })),
+                    },
+                    {
+                      title: 'Site 2',
+                      type: 'area',
+                      data: networkData.map((d) => ({ x: d.x, y: d.y2 })),
+                    },
+                  ]}
+                  xDomain={networkData.map((d) => d.x)}
+                  yDomain={[0, 100]}
+                  i18nStrings={{
+                    filterLabel: 'Filter displayed data',
+                    filterPlaceholder: 'Filter data',
+                    filterSelectedAriaLabel: 'selected',
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'area chart',
+                    xTickFormatter: (value) => value,
+                    yTickFormatter: (value) => `${value}`,
+                  }}
+                  ariaLabel="Network traffic area chart"
+                  height={300}
+                  xScaleType="categorical"
+                  xTitle="Day"
+                  yTitle="Traffic"
+                  empty={
+                    <Box textAlign="center" color="inherit">
+                      <b>No data available</b>
+                      <Box variant="p" color="inherit">
+                        There is no data available
+                      </Box>
+                    </Box>
+                  }
+                  noMatch={
+                    <Box textAlign="center" color="inherit">
+                      <b>No matching data</b>
+                      <Box variant="p" color="inherit">
+                        There is no matching data to display
+                      </Box>
+                    </Box>
+                  }
+                />
+              </Container>
+
+              <Container
+                header={
+                  <Header variant="h2" description="">
+                    Credit Usage
+                  </Header>
+                }
+              >
+                <BarChart
+                  key={`credit-${refreshKey}`}
+                  series={[
+                    {
+                      title: 'Site 1',
+                      type: 'bar',
+                      data: creditData,
+                    },
+                  ]}
+                  xDomain={creditData.map((d) => d.x)}
+                  yDomain={[0, 300]}
+                  i18nStrings={{
+                    filterLabel: 'Filter displayed data',
+                    filterPlaceholder: 'Filter data',
+                    filterSelectedAriaLabel: 'selected',
+                    legendAriaLabel: 'Legend',
+                    chartAriaRoleDescription: 'bar chart',
+                    xTickFormatter: (value) => value,
+                    yTickFormatter: (value) => `${value}`,
+                  }}
+                  ariaLabel="Credit usage bar chart"
+                  height={300}
+                  xScaleType="categorical"
+                  xTitle="Day"
+                  yTitle="Credits"
+                  empty={
+                    <Box textAlign="center" color="inherit">
+                      <b>No data available</b>
+                      <Box variant="p" color="inherit">
+                        There is no data available
+                      </Box>
+                    </Box>
+                  }
+                  noMatch={
+                    <Box textAlign="center" color="inherit">
+                      <b>No matching data</b>
+                      <Box variant="p" color="inherit">
+                        There is no matching data to display
+                      </Box>
+                    </Box>
+                  }
+                />
+              </Container>
+            </Grid>
+
+            <Table
+              header={
+                <Header
+                  variant="h2"
+                  description="Devices on your local network"
+                  actions={
+                    <Button variant="primary" iconName="external">
+                      Add Device
+                    </Button>
+                  }
+                >
+                  My Devices
+                </Header>
+              }
+              columnDefinitions={[
+                {
+                  id: 'name',
+                  header: 'Device Name',
+                  cell: (item) => item.name,
+                  sortingField: 'name',
+                },
+                {
+                  id: 'type',
+                  header: 'Type',
+                  cell: (item) => item.type,
+                  sortingField: 'type',
+                },
+                {
+                  id: 'ipAddress',
+                  header: 'IP Address',
+                  cell: (item) => item.ipAddress,
+                  sortingField: 'ipAddress',
+                },
+                {
+                  id: 'status',
+                  header: 'Status',
+                  cell: (item) => item.status,
+                  sortingField: 'status',
+                },
+                {
+                  id: 'location',
+                  header: 'Location',
+                  cell: (item) => item.location,
+                  sortingField: 'location',
+                },
+                {
+                  id: 'lastSeen',
+                  header: 'Last Seen',
+                  cell: (item) => item.lastSeen,
+                },
+              ]}
+              items={paginatedDevices}
+              selectionType="multi"
+              selectedItems={selectedItems}
+              onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+              filter={
+                <TextFilter
+                  filteringText={filteringText}
+                  filteringPlaceholder="Placeholder"
+                  filteringAriaLabel="Filter devices"
+                  onChange={({ detail }) => {
+                    setFilteringText(detail.filteringText);
+                    setCurrentPageIndex(1);
+                  }}
+                />
+              }
+              pagination={
+                <Pagination
+                  currentPageIndex={currentPageIndex}
+                  pagesCount={Math.ceil(filteredDevices.length / 5)}
+                  onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                />
+              }
+              preferences={
+                <CollectionPreferences
+                  title="Preferences"
+                  confirmLabel="Confirm"
+                  cancelLabel="Cancel"
+                  preferences={{
+                    pageSize: 5,
+                  }}
+                />
+              }
+              empty={
+                <Box textAlign="center" color="inherit">
+                  <b>No devices</b>
+                  <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+                    No devices to display.
+                  </Box>
+                  <Button>Add Device</Button>
+                </Box>
+              }
+              loadingText="Loading devices"
+            />
+          </SpaceBetween>
+        }
+        navigationHide={true}
+        toolsHide={true}
+      />
+    </>
+  );
+}

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -1,13 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 import React from 'react';
-import { createRoot } from 'react-dom/client';
 import { App } from './app';
-import { applyMode, Density } from '@cloudscape-design/global-styles';
 
-import '@cloudscape-design/global-styles/index.css';
+import '../../styles/base.scss';
 
-applyMode(Density.Comfortable);
-
-const root = createRoot(document.getElementById('app')!);
-root.render(<App />);
+export default function NetworkDashboardDemo() {
+  return <App />;
+}

--- a/src/pages/network-dashboard/index.tsx
+++ b/src/pages/network-dashboard/index.tsx
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './app';
+import { applyMode, Density } from '@cloudscape-design/global-styles';
+
+import '@cloudscape-design/global-styles/index.css';
+
+applyMode(Density.Comfortable);
+
+const root = createRoot(document.getElementById('app')!);
+root.render(<App />);


### PR DESCRIPTION
### Purpose
Based on the conversation, the user wanted to implement a new data dashboard from a Figma design. The goal was to create an interactive page to monitor network traffic, credit usage, and manage devices.

### Code changes
- Added a new **Network Administration Dashboard** page accessible at the `/network-dashboard` route.
- The new page is implemented in the `src/pages/network-dashboard/` directory.
- The dashboard features:
    - Dynamic area and bar charts for visualizing network traffic and credit usage.
    - A table to display and manage network devices, including features like filtering and pagination.
    - A "Refresh Data" button to update the dashboard's data.
- Added a link to the new dashboard on the main demos page (`src/pages/index.tsx`).

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/604730003d334a879c3dec2640e01fc0/stellar-den)

👀 [Preview Link](https://604730003d334a879c3dec2640e01fc0-stellar-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>604730003d334a879c3dec2640e01fc0</projectId>-->
<!--<branchName>stellar-den</branchName>-->