### PR TITLE
Add network administration dashboard page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -46,6 +46,12 @@ const dashboards = [
     category: 'Dashboards',
   },
   {
+    route: '/network-admin-dashboard',
+    title: 'Network Administration Dashboard',
+    description: 'Network traffic monitoring, credit usage, and device management.',
+    category: 'Dashboards',
+  },
+  {
     route: '/delete-one-click',
     title: 'Quick Delete',
     description: 'Streamlined resource deletion workflow.',

--- a/src/pages/network-admin-dashboard/app.tsx
+++ b/src/pages/network-admin-dashboard/app.tsx
@@ -1,0 +1,105 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+import AppLayout from '@cloudscape-design/components/app-layout';
+import ContentLayout from '@cloudscape-design/components/content-layout';
+import Header from '@cloudscape-design/components/header';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Button from '@cloudscape-design/components/button';
+import Grid from '@cloudscape-design/components/grid';
+import Container from '@cloudscape-design/components/container';
+import Flashbar from '@cloudscape-design/components/flashbar';
+import TextFilter from '@cloudscape-design/components/text-filter';
+import Pagination from '@cloudscape-design/components/pagination';
+import Icon from '@cloudscape-design/components/icon';
+
+import { Breadcrumbs } from '../commons';
+import { NetworkTrafficChart } from './components/network-traffic-chart';
+import { CreditUsageChart } from './components/credit-usage-chart';
+import { DevicesTable } from './components/devices-table';
+
+export function App() {
+  const [filteringText, setFilteringText] = useState('');
+  const [currentPageIndex, setCurrentPageIndex] = useState(1);
+  const [showWarning, setShowWarning] = useState(true);
+
+  return (
+    <AppLayout
+      navigationHide
+      toolsHide
+      breadcrumbs={
+        <Breadcrumbs
+          items={[
+            { text: 'Service', href: '/' },
+            { text: 'Administrative Dashboard', href: '#' },
+          ]}
+        />
+      }
+      notifications={
+        showWarning ? (
+          <Flashbar
+            items={[
+              {
+                type: 'warning',
+                content: 'This is a warning message',
+                dismissible: true,
+                onDismiss: () => setShowWarning(false),
+                dismissLabel: 'Dismiss',
+              },
+            ]}
+          />
+        ) : undefined
+      }
+      content={
+        <ContentLayout
+          header={
+            <SpaceBetween size="xs">
+              <Header
+                variant="h1"
+                description="Network Traffic, Credit Usage, and Your Devices"
+                actions={
+                  <Button variant="primary" iconName="external" iconAlign="right">
+                    Refresh Data
+                  </Button>
+                }
+              >
+                Network Administration Dashboard
+              </Header>
+              <Grid gridDefinition={[{ colspan: 6 }]}>
+                <TextFilter
+                  filteringText={filteringText}
+                  filteringPlaceholder="Placeholder"
+                  filteringAriaLabel="Filter instances"
+                  onChange={({ detail }) => setFilteringText(detail.filteringText)}
+                />
+              </Grid>
+              <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: '8px' }}>
+                <Pagination
+                  currentPageIndex={currentPageIndex}
+                  onChange={({ detail }) => setCurrentPageIndex(detail.currentPageIndex)}
+                  pagesCount={5}
+                  ariaLabels={{
+                    nextPageLabel: 'Next page',
+                    previousPageLabel: 'Previous page',
+                    pageLabel: pageNumber => `Page ${pageNumber}`,
+                  }}
+                />
+                <div style={{ width: '2px', height: '32px', background: '#414D5C' }} />
+                <Button variant="icon" iconName="settings" />
+              </div>
+            </SpaceBetween>
+          }
+        >
+          <SpaceBetween size="l">
+            <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+              <NetworkTrafficChart />
+              <CreditUsageChart />
+            </Grid>
+
+            <DevicesTable filteringText={filteringText} />
+          </SpaceBetween>
+        </ContentLayout>
+      }
+    />
+  );
+}

--- a/src/pages/network-admin-dashboard/components/credit-usage-chart.tsx
+++ b/src/pages/network-admin-dashboard/components/credit-usage-chart.tsx
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import Container from '@cloudscape-design/components/container';
+import BarChart from '@cloudscape-design/components/bar-chart';
+import Box from '@cloudscape-design/components/box';
+
+export function CreditUsageChart() {
+  return (
+    <Container>
+      <BarChart
+        series={[
+          {
+            title: 'Site 1',
+            type: 'bar',
+            data: [
+              { x: 'x1', y: 183 },
+              { x: 'x2', y: 257 },
+              { x: 'x3', y: 213 },
+              { x: 'x4', y: 122 },
+              { x: 'x5', y: 210 },
+            ],
+            valueFormatter: value => `${value}`,
+          },
+        ]}
+        xDomain={['x1', 'x2', 'x3', 'x4', 'x5']}
+        yDomain={[0, 300]}
+        i18nStrings={{
+          filterLabel: 'Filter displayed data',
+          filterPlaceholder: 'Filter data',
+          filterSelectedAriaLabel: 'selected',
+          detailPopoverDismissAriaLabel: 'Dismiss',
+          legendAriaLabel: 'Legend',
+          chartAriaRoleDescription: 'bar chart',
+          xTickFormatter: value => value,
+          yTickFormatter: value => `y${value}`,
+        }}
+        ariaLabel="Credit usage bar chart"
+        height={300}
+        xScaleType="categorical"
+        xTitle="Day"
+        yTitle="Credit Usage"
+        empty={
+          <Box textAlign="center" color="inherit">
+            <b>No data available</b>
+            <Box variant="p" color="inherit">
+              There is no data available
+            </Box>
+          </Box>
+        }
+        noMatch={
+          <Box textAlign="center" color="inherit">
+            <b>No matching data</b>
+            <Box variant="p" color="inherit">
+              There is no matching data to display
+            </Box>
+          </Box>
+        }
+        hideFilter
+      />
+    </Container>
+  );
+}

--- a/src/pages/network-admin-dashboard/components/devices-table.tsx
+++ b/src/pages/network-admin-dashboard/components/devices-table.tsx
@@ -1,0 +1,125 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React, { useState } from 'react';
+import Table from '@cloudscape-design/components/table';
+import Box from '@cloudscape-design/components/box';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import Button from '@cloudscape-design/components/button';
+import Header from '@cloudscape-design/components/header';
+
+interface Device {
+  id: string;
+  column1: string;
+  column2: string;
+  column3: string;
+  column4: string;
+  column5: string;
+  column6: string;
+  column7: string;
+}
+
+const generateDevices = (): Device[] => {
+  const devices: Device[] = [];
+  for (let i = 1; i <= 12; i++) {
+    devices.push({
+      id: `device-${i}`,
+      column1: 'Cell Value',
+      column2: 'Cell Value',
+      column3: 'Cell Value',
+      column4: 'Cell Value',
+      column5: 'Cell Value',
+      column6: 'Cell Value',
+      column7: 'Cell Value',
+    });
+  }
+  return devices;
+};
+
+interface DevicesTableProps {
+  filteringText: string;
+}
+
+export function DevicesTable({ filteringText }: DevicesTableProps) {
+  const [selectedItems, setSelectedItems] = useState<Device[]>([]);
+  const allDevices = generateDevices();
+
+  const filteredDevices = allDevices.filter(device =>
+    Object.values(device).some(value => value.toLowerCase().includes(filteringText.toLowerCase())),
+  );
+
+  return (
+    <Table
+      columnDefinitions={[
+        {
+          id: 'column1',
+          header: 'Column header',
+          cell: item => item.column1,
+          sortingField: 'column1',
+        },
+        {
+          id: 'column2',
+          header: 'Column header',
+          cell: item => item.column2,
+          sortingField: 'column2',
+        },
+        {
+          id: 'column3',
+          header: 'Column header',
+          cell: item => item.column3,
+          sortingField: 'column3',
+        },
+        {
+          id: 'column4',
+          header: 'Column header',
+          cell: item => item.column4,
+          sortingField: 'column4',
+        },
+        {
+          id: 'column5',
+          header: 'Column header',
+          cell: item => item.column5,
+          sortingField: 'column5',
+        },
+        {
+          id: 'column6',
+          header: 'Column header',
+          cell: item => item.column6,
+          sortingField: 'column6',
+        },
+        {
+          id: 'column7',
+          header: 'Column header',
+          cell: item => item.column7,
+          sortingField: 'column7',
+        },
+      ]}
+      items={filteredDevices}
+      loadingText="Loading devices"
+      selectionType="multi"
+      trackBy="id"
+      empty={
+        <Box textAlign="center" color="inherit">
+          <Box padding={{ bottom: 's' }} variant="p" color="inherit">
+            <b>No devices</b>
+          </Box>
+          <Button>Add device</Button>
+        </Box>
+      }
+      header={
+        <Header
+          variant="h2"
+          description="Devices on your local network"
+          actions={
+            <Button variant="primary" iconName="external" iconAlign="right">
+              Add Device
+            </Button>
+          }
+        >
+          My Devices
+        </Header>
+      }
+      selectedItems={selectedItems}
+      onSelectionChange={({ detail }) => setSelectedItems(detail.selectedItems)}
+    />
+  );
+}

--- a/src/pages/network-admin-dashboard/components/network-traffic-chart.tsx
+++ b/src/pages/network-admin-dashboard/components/network-traffic-chart.tsx
@@ -1,0 +1,88 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import Container from '@cloudscape-design/components/container';
+import AreaChart from '@cloudscape-design/components/area-chart';
+import Box from '@cloudscape-design/components/box';
+
+export function NetworkTrafficChart() {
+  return (
+    <Container>
+      <AreaChart
+        series={[
+          {
+            title: 'Site 1',
+            type: 'area',
+            data: [
+              { x: 'x1', y: 3 },
+              { x: 'x2', y: 3.2 },
+              { x: 'x3', y: 3.5 },
+              { x: 'x4', y: 3.8 },
+              { x: 'x5', y: 4.2 },
+              { x: 'x6', y: 4.8 },
+              { x: 'x7', y: 5.2 },
+              { x: 'x8', y: 5 },
+              { x: 'x9', y: 5.3 },
+              { x: 'x10', y: 5.5 },
+              { x: 'x11', y: 5.2 },
+              { x: 'x12', y: 4.8 },
+            ],
+            valueFormatter: value => `${value}`,
+          },
+          {
+            title: 'Site 2',
+            type: 'area',
+            data: [
+              { x: 'x1', y: 2.5 },
+              { x: 'x2', y: 2.8 },
+              { x: 'x3', y: 2.6 },
+              { x: 'x4', y: 2.9 },
+              { x: 'x5', y: 3.2 },
+              { x: 'x6', y: 3.5 },
+              { x: 'x7', y: 2.8 },
+              { x: 'x8', y: 2.2 },
+              { x: 'x9', y: 2.5 },
+              { x: 'x10', y: 1.8 },
+              { x: 'x11', y: 1.5 },
+              { x: 'x12', y: 2.2 },
+            ],
+            valueFormatter: value => `${value}`,
+          },
+        ]}
+        xDomain={['x1', 'x2', 'x3', 'x4', 'x5', 'x6', 'x7', 'x8', 'x9', 'x10', 'x11', 'x12']}
+        yDomain={[0, 6]}
+        i18nStrings={{
+          filterLabel: 'Filter displayed data',
+          filterPlaceholder: 'Filter data',
+          filterSelectedAriaLabel: 'selected',
+          detailPopoverDismissAriaLabel: 'Dismiss',
+          legendAriaLabel: 'Legend',
+          chartAriaRoleDescription: 'area chart',
+          xTickFormatter: value => value,
+          yTickFormatter: value => `y${value}`,
+        }}
+        ariaLabel="Network traffic area chart"
+        height={300}
+        xScaleType="categorical"
+        xTitle="Day"
+        yTitle="Network traffic"
+        empty={
+          <Box textAlign="center" color="inherit">
+            <b>No data available</b>
+            <Box variant="p" color="inherit">
+              There is no data available
+            </Box>
+          </Box>
+        }
+        noMatch={
+          <Box textAlign="center" color="inherit">
+            <b>No matching data</b>
+            <Box variant="p" color="inherit">
+              There is no matching data to display
+            </Box>
+          </Box>
+        }
+      />
+    </Container>
+  );
+}

--- a/src/pages/network-admin-dashboard/index.tsx
+++ b/src/pages/network-admin-dashboard/index.tsx
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+import React from 'react';
+import { App } from './app';
+
+import '../../styles/base.scss';
+
+export default function NetworkAdminDashboard() {
+  return <App />;
+}


### PR DESCRIPTION
## Summary
This PR introduces the Network Administration Dashboard, featuring network traffic monitoring, credit usage analytics, and a device management table.

## Problem
A new dashboard interface was required to visualize network performance metrics and manage connected devices, based on the provided design specifications.

## Solution
Implemented a responsive page using Cloudscape Design components. The dashboard is structured with modular components for charts and tables to ensure maintainability and responsiveness across different device sizes.

## Key Changes
*   Added new dashboard route and entry in the main navigation.
*   Implemented `NetworkTrafficChart` using an Area Chart.
*   Implemented `CreditUsageChart` using a Bar Chart.
*   Created `DevicesTable` with search/filtering, multi-selection, and pagination support.
*   Utilized `AppLayout` and `ContentLayout` for a consistent, responsive UI structure.

## Files Changed
*   `src/pages/index.tsx`: Added navigation entry for the new dashboard.
*   `src/pages/network-admin-dashboard/app.tsx`: Main application layout and state management.
*   `src/pages/network-admin-dashboard/components/credit-usage-chart.tsx`: Added credit usage bar chart component.
*   `src/pages/network-admin-dashboard/components/network-traffic-chart.tsx`: Added network traffic area chart component.
*   `src/pages/network-admin-dashboard/components/devices-table.tsx`: Added devices table with filtering logic.
*   `src/pages/network-admin-dashboard/index.tsx`: Entry point for the new route.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/604730003d334a879c3dec2640e01fc0/pulse-world)

👀 [Preview Link](https://604730003d334a879c3dec2640e01fc0-pulse-world.projects.builder.my/)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 13`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>604730003d334a879c3dec2640e01fc0</projectId>-->
<!--<branchName>pulse-world</branchName>-->